### PR TITLE
SATSolver: fix handling conflict clause

### DIFF
--- a/app/ipasir-check-conflict/SATSolver.h
+++ b/app/ipasir-check-conflict/SATSolver.h
@@ -99,9 +99,8 @@ public:
     } else if (SATret == 20) {
       conflict.clear();
       for( int i=0; i < assumptions.size(); ++i ) {
-	int v = assumptions[i] > 0 ? assumptions[i] : -assumptions[i];
-	IPASIR( /*std::cerr << "c failed " << v << std::endl; */ if(ipasir_failed(ipasirSolver,  v)) conflict.push_back( assumptions[i]); );
-	IPASIR( /*std::cerr << "c failed " << -v << std::endl;*/ if(ipasir_failed(ipasirSolver, -v)) conflict.push_back(-assumptions[i]); );
+	IPASIR( if(ipasir_failed(ipasirSolver,  assumptions[i])) conflict.push_back(-assumptions[i]);
+	        else if(ipasir_failed(ipasirSolver, -assumptions[i])) conflict.push_back(-assumptions[i]); );
       }
     } else {
       std::cerr << "ipasir SAT solver terminated with unexpected exit code: " << SATret << ". Abort." << std::endl;

--- a/app/ipasir-check-iterative/SATSolver.h
+++ b/app/ipasir-check-iterative/SATSolver.h
@@ -99,9 +99,8 @@ public:
     } else if (SATret == 20) {
       conflict.clear();
       for( int i=0; i < assumptions.size(); ++i ) {
-	int v = assumptions[i] > 0 ? assumptions[i] : -assumptions[i];
-	IPASIR( /*std::cerr << "c failed " << v << std::endl; */ if(ipasir_failed(ipasirSolver,  v)) conflict.push_back( assumptions[i]); );
-	IPASIR( /*std::cerr << "c failed " << -v << std::endl;*/ if(ipasir_failed(ipasirSolver, -v)) conflict.push_back(-assumptions[i]); );
+	IPASIR( if(ipasir_failed(ipasirSolver,  assumptions[i])) conflict.push_back(-assumptions[i]);
+	        else if(ipasir_failed(ipasirSolver, -assumptions[i])) conflict.push_back(-assumptions[i]); );
       }
     } else {
       std::cerr << "ipasir SAT solver terminated with unexpected exit code: " << SATret << ". Abort." << std::endl;

--- a/app/ipasir-check-satunsat/SATSolver.h
+++ b/app/ipasir-check-satunsat/SATSolver.h
@@ -99,9 +99,8 @@ public:
     } else if (SATret == 20) {
       conflict.clear();
       for( int i=0; i < assumptions.size(); ++i ) {
-	int v = assumptions[i] > 0 ? assumptions[i] : -assumptions[i];
-	IPASIR( /*std::cerr << "c failed " << v << std::endl; */ if(ipasir_failed(ipasirSolver,  v)) conflict.push_back( assumptions[i]); );
-	IPASIR( /*std::cerr << "c failed " << -v << std::endl;*/ if(ipasir_failed(ipasirSolver, -v)) conflict.push_back(-assumptions[i]); );
+	IPASIR( if(ipasir_failed(ipasirSolver,  assumptions[i])) conflict.push_back(-assumptions[i]);
+	        else if(ipasir_failed(ipasirSolver, -assumptions[i])) conflict.push_back(-assumptions[i]); );
       }
     } else {
       std::cerr << "ipasir SAT solver terminated with unexpected exit code: " << SATret << ". Abort." << std::endl;


### PR DESCRIPTION
Older solvers did not differentiate when reporting failed
literals via the ipasir interface - they reported on a variable
granularity. More recent solvers like CaDiCaL and MergeSat report
on a per-literal basis. Hence, the code needed to be adapted to
fit the two reporting styles.

Signed-off-by: Norbert Manthey <nmanthey@conp-solutions.com>